### PR TITLE
Fixes for upstream

### DIFF
--- a/nextcloud.yaml
+++ b/nextcloud.yaml
@@ -275,7 +275,7 @@ objects:
       name: nextcloud
       weight: 100
     wildcardPolicy: None
-- apiVersion: batch/v2alpha1
+- apiVersion: batch/v1beta1
   kind: CronJob
   metadata:
     name: nextcloud-cron

--- a/nextcloud.yaml
+++ b/nextcloud.yaml
@@ -292,6 +292,8 @@ objects:
               - -f
               - /var/www/html/cron.php
               env:
+              - name: NEXTCLOUD_UPDATE
+                value: "1"
               - name: NC_dbhost
                 value: mariadb
               - name: NC_dbuser


### PR DESCRIPTION
Two changes:
- CronJob configuration: Fix for deprecated batch/v2alpha1 API 
- CronJob environment: Fix for the CRON job environment: run nextcloud installation so that /var/www/html is filled
